### PR TITLE
Update interop.cc

### DIFF
--- a/src/lycon/python/interop.cc
+++ b/src/lycon/python/interop.cc
@@ -318,7 +318,7 @@ PyObject* ndarray_from_mat(const Mat& mat)
 std::string string_from_pyobject(PyObject* object)
 {
     PYCON_ASSERT_NOT_NONE(object);
-    char* str = PyString_AsString(object);
+    const char* str = PyString_AsString(object);
     LYCON_ASSERT(str)
     return std::string(str);
 }


### PR DESCRIPTION
This is to address issue #16 which has also occurred on Arch Linux with Python 3.7.0 & GCC 8.1.1. PyString_AsString is mapped to PyUnicode_AsUTF8 in [src/lycon/python/compat.h](https://github.com/ethereon/lycon/blob/master/src/lycon/python/compat.h#L25) for compatibility. And based on the function signiture `const char* PyUnicode_AsUTF8(PyObject *unicode)`, I have prefixed `const` to make this correct. In Python2 it was defined to return char* however the content of the string mustn't be modified. This change is a backward compatible easy fix. Please consider merging soon. Thanks.

(Reference: https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF8)
